### PR TITLE
Separate sarama config for sync and async client

### DIFF
--- a/kafka.go
+++ b/kafka.go
@@ -33,11 +33,13 @@ type KafkaClient struct {
 
 // NewKafkaClient creates new client to publish event to kafka
 func NewKafkaClient(realm string, brokerList []string) (*KafkaClient, error) {
-	config := sarama.NewConfig()
-	asyncProducer, err := sarama.NewAsyncProducer(brokerList, config)
+	configAsync := sarama.NewConfig()
+	asyncProducer, err := sarama.NewAsyncProducer(brokerList, configAsync)
 	if err != nil {
 		return nil, err
 	}
+
+	config := sarama.NewConfig()
 	config.Producer.Return.Successes = true
 	syncProducer, err := sarama.NewSyncProducer(brokerList, config)
 	if err != nil {


### PR DESCRIPTION
Sync client need the return.success to be true. If that's set to true
in the async client, we need to read from channel to avoid blocking.