### PR TITLE
fix(publish): fix auto create kafka topic

### DIFF
--- a/.github/workflows/github-action-test.yml
+++ b/.github/workflows/github-action-test.yml
@@ -1,0 +1,31 @@
+name: Github Action Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        docker-compose: [ 1.24.0 ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Download Golangci-lint
+        run: sudo curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sudo bash -s -- -b $GOPATH/bin v1.23.6
+      - name: Remove existing docker-compose
+        run: sudo rm /usr/local/bin/docker-compose
+      - name: Download docker-compose
+        run: sudo curl -L https://github.com/docker/compose/releases/download/${{ matrix.docker-compose }}/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+      - name: Allow executing docker-compose
+        run: sudo chmod +x /usr/local/bin/docker-compose
+      - name: Run Test
+        run: make test

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -37,7 +37,6 @@ services:
       - KAFKA_ADVERTISED_PORT=9092
       - KAFKA_ADVERTISED_HOST_NAME=localhost
       - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
-      - KAFKA_CREATE_TOPICS=prefix.testTopic:1:1
     networks:
       - resource-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,6 @@ services:
       - KAFKA_ADVERTISED_PORT=9092
       - KAFKA_ADVERTISED_HOST_NAME=kafka
       - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
-      - KAFKA_CREATE_TOPICS=prefix.testTopic:1:1
     networks:
       - resource-network
 

--- a/validation.go
+++ b/validation.go
@@ -39,7 +39,7 @@ func validatePublishEvent(publishBuilder *PublishBuilder, strictValidation bool)
 	publishEvent := struct {
 		Topic     []string `valid:"required"`
 		EventName string   `valid:"alphanum,stringlength(1|256),required"`
-		Namespace string   `valid:"alphanum,stringlength(1|256),required"`
+		Namespace string
 		ClientID  string
 		UserID    string
 		SessionID string


### PR DESCRIPTION
fix(auto-create-topic): 
- Fix auto create kafka topic by adding temporary workaround. refer to this [issue](https://github.com/segmentio/kafka-go/issues/683)
- Tidy-up log message by adding topic and event name in the log
- Remove namespace validation since some event doesn't have namespace
- Add GitHub Actions