### PR TITLE
feat(message-key): add message key

### DIFF
--- a/eventstream.go
+++ b/eventstream.go
@@ -33,7 +33,6 @@ const (
 const (
 	separator      = "."
 	defaultVersion = 1
-	defaultGroupID = "*"
 )
 
 // log level
@@ -68,6 +67,10 @@ type Event struct {
 	Topic            string                 `json:"topic"`
 	AdditionalFields map[string]interface{} `json:"additional_fields,omitempty"`
 	Payload          map[string]interface{} `json:"payload"`
+
+	Partition int    `json:",omitempty"`
+	Offset    int64  `json:",omitempty"`
+	Key       string `json:",omitempty"`
 }
 
 // BrokerConfig is custom configuration for message broker
@@ -101,6 +104,7 @@ type PublishBuilder struct {
 	targetNamespace  string
 	privacy          bool
 	additionalFields map[string]interface{}
+	key              string
 	payload          map[string]interface{}
 	errorCallback    func(event *Event, err error)
 	ctx              context.Context
@@ -220,6 +224,13 @@ func (p *PublishBuilder) Privacy(privacy bool) *PublishBuilder {
 // AdditionalFields set AdditionalFields of publisher event
 func (p *PublishBuilder) AdditionalFields(additionalFields map[string]interface{}) *PublishBuilder {
 	p.additionalFields = additionalFields
+	return p
+}
+
+// Key is a message key that used to determine the partition of the topic
+// if client require strong order for the events
+func (p *PublishBuilder) Key(key string) *PublishBuilder {
+	p.key = key
 	return p
 }
 

--- a/kafka_integration_test.go
+++ b/kafka_integration_test.go
@@ -33,6 +33,7 @@ const (
 	timeoutTest    = 60
 	prefix         = "prefix"
 	testPayload    = "testPayload"
+	testKey        = "testKey"
 	errorTimeout   = "timeout while executing test"
 	errorPublish   = "error when publish event"
 	errorSubscribe = "error when subscribe event"
@@ -120,6 +121,7 @@ func TestKafkaPubSubSuccess(t *testing.T) {
 		Privacy:          true,
 		AdditionalFields: mockAdditionalFields,
 		Version:          defaultVersion,
+		Key:              testKey,
 		Payload:          mockPayload,
 	}
 
@@ -159,6 +161,7 @@ func TestKafkaPubSubSuccess(t *testing.T) {
 				assert.Equal(t, mockEvent.Privacy, event.Privacy, "Privacy should be equal")
 				assert.Equal(t, mockEvent.AdditionalFields, event.AdditionalFields, "AdditionalFields should be equal")
 				assert.Equal(t, mockEvent.Version, event.Version, "version should be equal")
+				assert.Equal(t, mockEvent.Key, event.Key, "key should be equal")
 				if validPayload := reflect.DeepEqual(mockEvent.Payload[testPayload].(Payload), eventPayload); !validPayload {
 					assert.Fail(t, "payload should be equal")
 				}
@@ -188,6 +191,7 @@ func TestKafkaPubSubSuccess(t *testing.T) {
 			TargetNamespace(mockEvent.TargetNamespace).
 			Privacy(mockEvent.Privacy).
 			AdditionalFields(mockEvent.AdditionalFields).
+			Key(testKey).
 			Payload(mockPayload))
 	if err != nil {
 		assert.FailNow(t, errorPublish, err)

--- a/utils.go
+++ b/utils.go
@@ -36,7 +36,7 @@ func constructTopic(prefix, topic string) string {
 // constructGroupID construct groupID or queue group name
 func constructGroupID(prefix, groupID string) string {
 	if groupID == "" {
-		groupID = defaultGroupID
+		return ""
 	}
 
 	return prefix + separator + groupID


### PR DESCRIPTION
 - support message key in publisher parameter to enable order guarantee
- recreate reader object once got fail
- remove default group ID if client set it as empty