### PR TITLE
Loadtest notifications changes

### DIFF
--- a/eventstream.go
+++ b/eventstream.go
@@ -73,6 +73,11 @@ type Event struct {
 	Key       string `json:",omitempty"`
 }
 
+var (
+	NotificationEventNamePath       = "name"
+	FreeformNotificationUserIDsPath = [...]string{"payload", "userIds"}
+)
+
 // BrokerConfig is custom configuration for message broker
 type BrokerConfig struct {
 	StrictValidation bool

--- a/eventstream.go
+++ b/eventstream.go
@@ -75,7 +75,7 @@ type Event struct {
 
 var (
 	NotificationEventNamePath       = "name"
-	FreeformNotificationUserIDsPath = [...]string{"payload", "userIds"}
+	FreeformNotificationUserIDsPath = []string{"payload", "userIds"}
 )
 
 // BrokerConfig is custom configuration for message broker

--- a/eventstream.go
+++ b/eventstream.go
@@ -262,12 +262,13 @@ func (p *PublishBuilder) Context(ctx context.Context) *PublishBuilder {
 
 // SubscribeBuilder defines the structure of message which is sent through message broker
 type SubscribeBuilder struct {
-	topic     string
-	groupID   string
-	offset    int64
-	callback  func(ctx context.Context, event *Event, err error) error
-	eventName string
-	ctx       context.Context
+	topic       string
+	groupID     string
+	offset      int64
+	callback    func(ctx context.Context, event *Event, err error) error
+	eventName   string
+	ctx         context.Context
+	callbackRaw func(ctx context.Context, msgValue []byte, err error) error
 }
 
 // NewSubscribe create new SubscribeBuilder instance
@@ -307,6 +308,14 @@ func (s *SubscribeBuilder) Callback(
 	callback func(ctx context.Context, event *Event, err error) error,
 ) *SubscribeBuilder {
 	s.callback = callback
+	return s
+}
+
+// CallbackRaw callback that receives the undecoded payload
+func (s *SubscribeBuilder) CallbackRaw(
+	f func(ctx context.Context, msgValue []byte, err error) error,
+) *SubscribeBuilder {
+	s.callbackRaw = f
 	return s
 }
 

--- a/kafka.go
+++ b/kafka.go
@@ -440,7 +440,12 @@ func (client *KafkaClient) Register(subscribeBuilder *SubscribeBuilder) error {
 			select {
 			case <-subscribeBuilder.ctx.Done():
 				// ignore error because client isn't processing events
-				err = subscribeBuilder.callback(subscribeBuilder.ctx, nil, subscribeBuilder.ctx.Err())
+				if subscribeBuilder.callback != nil {
+					err = subscribeBuilder.callback(subscribeBuilder.ctx, nil, subscribeBuilder.ctx.Err())
+				}
+				if subscribeBuilder.callbackRaw != nil {
+					err = subscribeBuilder.callbackRaw(subscribeBuilder.ctx, nil, subscribeBuilder.ctx.Err())
+				}
 
 				logrus.
 					WithField("Topic Name", topic).

--- a/kafka.go
+++ b/kafka.go
@@ -577,7 +577,12 @@ func (client *KafkaClient) deleteWriter(topic string) {
 
 // processMessage process a message from kafka
 func (client *KafkaClient) processMessage(subscribeBuilder *SubscribeBuilder, message kafka.Message, topic string) error {
+	if subscribeBuilder.callbackRaw != nil {
+		return subscribeBuilder.callbackRaw(subscribeBuilder.ctx, message.Value, nil)
+	}
+
 	event, err := unmarshal(message)
+
 	if err != nil {
 		logrus.
 			WithField("Topic Name", topic).

--- a/validation.go
+++ b/validation.go
@@ -40,7 +40,7 @@ var (
 
 var topicRegex *regexp.Regexp = nil
 
-func init () {
+func init() {
 	validRegex, err := regexp.Compile(TopicEventPattern)
 	if err != nil {
 		panic(err)
@@ -142,15 +142,17 @@ func validateSubscribeEvent(subscribeBuilder *SubscribeBuilder) error {
 	}
 
 	subscribeEvent := struct {
-		Topic     string `valid:"required"`
-		EventName string `valid:"required"`
-		GroupID   string
-		Callback  func(ctx context.Context, event *Event, err error) error
+		Topic       string `valid:"required"`
+		EventName   string `valid:"required"`
+		GroupID     string
+		Callback    func(ctx context.Context, event *Event, err error) error
+		CallbackRaw func(ctx context.Context, msg []byte, err error) error
 	}{
-		Topic:     subscribeBuilder.topic,
-		EventName: subscribeBuilder.eventName,
-		GroupID:   subscribeBuilder.groupID,
-		Callback:  subscribeBuilder.callback,
+		Topic:       subscribeBuilder.topic,
+		EventName:   subscribeBuilder.eventName,
+		GroupID:     subscribeBuilder.groupID,
+		Callback:    subscribeBuilder.callback,
+		CallbackRaw: subscribeBuilder.callbackRaw,
 	}
 
 	_, err := validator.ValidateStruct(subscribeEvent)
@@ -162,7 +164,7 @@ func validateSubscribeEvent(subscribeBuilder *SubscribeBuilder) error {
 		return err
 	}
 
-	if subscribeEvent.Callback == nil {
+	if subscribeEvent.Callback == nil && subscribeEvent.CallbackRaw == nil {
 		return errInvalidCallback
 	}
 


### PR DESCRIPTION
I added a separate callback that doesn't unmarshall the event before passing it as an argument. It passes the raw message instead.
[Loadtest ticket](https://accelbyte.atlassian.net/browse/AR-3580)