### PR TITLE
feat: Add parent namespace on event struct

### DIFF
--- a/eventstream.go
+++ b/eventstream.go
@@ -49,6 +49,7 @@ type Event struct {
 	ID               string                 `json:"id,omitempty"`
 	EventName        string                 `json:"name,omitempty"`
 	Namespace        string                 `json:"namespace,omitempty"`
+	ParentNamespace  string                 `json:"parent_namespace,omitempty"`
 	ClientID         string                 `json:"clientId,omitempty"`
 	TraceID          string                 `json:"traceId,omitempty"`
 	SpanContext      string                 `json:"spanContext,omitempty"`

--- a/eventstream.go
+++ b/eventstream.go
@@ -102,6 +102,7 @@ type PublishBuilder struct {
 	topic            []string
 	eventName        string
 	namespace        string
+	parentNamespace  string
 	clientID         string
 	traceID          string
 	spanContext      string
@@ -147,6 +148,11 @@ func (p *PublishBuilder) EventName(eventName string) *PublishBuilder {
 // Namespace set namespace of published event
 func (p *PublishBuilder) Namespace(namespace string) *PublishBuilder {
 	p.namespace = namespace
+	return p
+}
+
+func (p *PublishBuilder) ParentNamespace(parentNamespace string) *PublishBuilder {
+	p.parentNamespace = parentNamespace
 	return p
 }
 

--- a/kafka.go
+++ b/kafka.go
@@ -321,6 +321,7 @@ func ConstructEvent(publishBuilder *PublishBuilder) (kafka.Message, *Event, erro
 		ID:               id,
 		EventName:        publishBuilder.eventName,
 		Namespace:        publishBuilder.namespace,
+		ParentNamespace:  publishBuilder.parentNamespace,
 		ClientID:         publishBuilder.clientID,
 		UserID:           publishBuilder.userID,
 		TraceID:          publishBuilder.traceID,


### PR DESCRIPTION
Related to PI-786, in Foundations we need to send event to analytics with `parent_namespace` info in the header info. 