### PR TITLE
feat: change publish retries using context to allow context timeout f…

### DIFF
--- a/kafka_integration_test.go
+++ b/kafka_integration_test.go
@@ -439,6 +439,9 @@ func TestKafkaPubFailed(t *testing.T) {
 		doneChan <- true
 	}
 
+	eventCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+
 	err := client.Publish(
 		NewPublish().
 			Topic(topicName).
@@ -449,7 +452,7 @@ func TestKafkaPubFailed(t *testing.T) {
 			SessionID(mockEvent.SessionID).
 			TraceID(mockEvent.TraceID).
 			SpanContext(mockEvent.SpanContext).
-			Context(context.Background()).
+			Context(eventCtx).
 			EventID(mockEvent.EventID).
 			EventType(mockEvent.EventType).
 			EventLevel(mockEvent.EventLevel).


### PR DESCRIPTION
when the library is using backoff.maxRetries, the publisher is unable to pass context and control how long it will give up publish events. in case the publisher has more events to send, since the library spins up goroutines during event publish, the publisher will have more goroutines hanging to wait for a response for the streaming pipeline, and eventually OOM.
by changing into using backoff withContext, the publisher can pass a context and put a timeout, therefore having better control over how long it wants to wait before dropping the message. 