### PR TITLE
chore: allow empty event name when subscribe

### DIFF
--- a/validation.go
+++ b/validation.go
@@ -133,17 +133,19 @@ func validateSubscribeEvent(subscribeBuilder *SubscribeBuilder) error {
 		return errInvalidTopicFormat
 	}
 
-	if isEventNameValid := validateTopicEvent(subscribeBuilder.eventName); !isEventNameValid {
-		logrus.
-			WithField("Topic Name", subscribeBuilder.topic).
-			WithField("Event Name", subscribeBuilder.eventName).
-			Errorf("unable to validate subscribe event. error: invalid event name format")
-		return errInvalidEventNameFormat
+	if subscribeBuilder.eventName != "" {
+		if isEventNameValid := validateTopicEvent(subscribeBuilder.eventName); !isEventNameValid {
+			logrus.
+				WithField("Topic Name", subscribeBuilder.topic).
+				WithField("Event Name", subscribeBuilder.eventName).
+				Errorf("unable to validate subscribe event. error: invalid event name format")
+			return errInvalidEventNameFormat
+		}
 	}
 
 	subscribeEvent := struct {
 		Topic       string `valid:"required"`
-		EventName   string `valid:"required"`
+		EventName   string
 		GroupID     string
 		Callback    func(ctx context.Context, event *Event, err error) error
 		CallbackRaw func(ctx context.Context, msg []byte, err error) error

--- a/validation_test.go
+++ b/validation_test.go
@@ -221,6 +221,14 @@ func TestValidateSubscriberEvent(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			input: &SubscribeBuilder{
+				topic:     "accelbyte.dev.topic-123",
+				eventName: "",
+				callback:  callbackFunc,
+			},
+			expected: true,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Multiple subscribe of a topic but different event name cause the application wasting resource. The event name should be filtered on application level instead on the SDK level.
This PR was allowing to register a call back with empty event name.