### PR TITLE
fix(v3): race condition set AllowAutoTopicCreation

### DIFF
--- a/v3/kafka.go
+++ b/v3/kafka.go
@@ -359,7 +359,6 @@ func (client *KafkaClient) publishEvent(ctx context.Context, topic, eventName st
 
 	config.Topic = topic
 	writer = client.getWriter(config)
-	writer.AllowAutoTopicCreation = true
 	err = writer.WriteMessages(ctx, message)
 	if err != nil {
 		if errors.Is(err, io.ErrClosedPipe) {
@@ -663,6 +662,7 @@ func (client *KafkaClient) getWriter(config kafka.WriterConfig) *kafka.Writer {
 	}
 
 	writer := kafka.NewWriter(config)
+	writer.AllowAutoTopicCreation = true
 	client.writers[config.Topic] = writer
 
 	return writer


### PR DESCRIPTION
Found race condition when building chat service
This is minor since the AllowAutoTopicCreation value is always set to true
We need this to pass the chat service build
```WARNING: DATA RACE
Write at 0x00c006609740 by goroutine 23813:
  github.com/AccelByte/eventstream-go-sdk/v3.(*KafkaClient).publishEvent()
      /opt/go/pkg/mod/github.com/!accel!byte/eventstream-go-sdk/v3@v3.17.0/kafka.go:362 +0x445
  github.com/AccelByte/eventstream-go-sdk/v3.(*KafkaClient).publishAndRetryFailure.func1.1()
      /opt/go/pkg/mod/github.com/!accel!byte/eventstream-go-sdk/v3@v3.17.0/kafka.go:408 +0x1cf
  github.com/cenkalti/backoff.RetryNotify()
      /opt/go/pkg/mod/github.com/cenkalti/backoff@v2.2.1+incompatible/retry.go:37 +0x248
  github.com/AccelByte/eventstream-go-sdk/v3.(*KafkaClient).publishAndRetryFailure.func1()
      /opt/go/pkg/mod/github.com/!accel!byte/eventstream-go-sdk/v3@v3.17.0/kafka.go:407 +0x304

Previous read at 0x00c006609740 by goroutine 23769:
  github.com/segmentio/kafka-go.(*Writer).partitions()
      /opt/go/pkg/mod/github.com/segmentio/kafka-go@v0.4.42/writer.go:754 +0x313
  github.com/segmentio/kafka-go.(*Writer).WriteMessages()
      /opt/go/pkg/mod/github.com/segmentio/kafka-go@v0.4.42/writer.go:651 +0x936
  github.com/AccelByte/eventstream-go-sdk/v3.(*KafkaClient).publishEvent()
      /opt/go/pkg/mod/github.com/!accel!byte/eventstream-go-sdk/v3@v3.17.0/kafka.go:363 +0x504
  github.com/AccelByte/eventstream-go-sdk/v3.(*KafkaClient).publishAndRetryFailure.func1.1()
      /opt/go/pkg/mod/github.com/!accel!byte/eventstream-go-sdk/v3@v3.17.0/kafka.go:408 +0x1cf
  github.com/cenkalti/backoff.RetryNotify()
      /opt/go/pkg/mod/github.com/cenkalti/backoff@v2.2.1+incompatible/retry.go:37 +0x248
  github.com/AccelByte/eventstream-go-sdk/v3.(*KafkaClient).publishAndRetryFailure.func1()
      /opt/go/pkg/mod/github.com/!accel!byte/eventstream-go-sdk/v3@v3.17.0/kafka.go:407 +0x304

Goroutine 23813 (running) created at:
  github.com/AccelByte/eventstream-go-sdk/v3.(*KafkaClient).publishAndRetryFailure()
      /opt/go/pkg/mod/github.com/!accel!byte/eventstream-go-sdk/v3@v3.17.0/kafka.go:406 +0x3e7
  github.com/AccelByte/eventstream-go-sdk/v3.(*KafkaClient).PublishAuditLog()
      /opt/go/pkg/mod/github.com/!accel!byte/eventstream-go-sdk/v3@v3.17.0/kafka.go:394 +0x204
  accelbyte.net/justice-chat-service/pkg/auditlog.(*Publisher).PublishAuditLogWithOptions()
      /opt/go/src/accelbyte.net/justice-chat-service/pkg/auditlog/auditlog.go:246 +0xcf1
  accelbyte.net/justice-chat-service/pkg/filter/api.(*Handler).handleDelete()
      /opt/go/src/accelbyte.net/justice-chat-service/pkg/filter/api/handler.go:281 +0x385
  accelbyte.net/justice-chat-service/pkg/filter/api.(*Handler).handleDelete-fm()
      <autogenerated>:1 +0x47
  github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/filter.go:23 +0x141
  accelbyte.net/justice-chat-service/pkg/route-filters.WrapWithAuthFilter.(*Filter).Auth.func3()
      /opt/go/pkg/mod/github.com/!accel!byte/go-restful-plugins/v4@v4.21.0/pkg/auth/iam/iam.go:207 +0xb5d
  github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/filter.go:21 +0x11b
  accelbyte.net/justice-chat-service/pkg/filter/api.AddAdminProfanityV1Route.ValidatePathParams.func11()
      /opt/go/src/accelbyte.net/justice-chat-service/pkg/utils/restapi/validationfilter.go:54 +0x6b5
  github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/filter.go:21 +0x11b
  accelbyte.net/justice-chat-service/pkg/server.New.Log.func6()
      /opt/go/pkg/mod/github.com/!accel!byte/go-restful-plugins/v4@v4.21.0/pkg/logger/event/event.go:91 +0x209
  github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/filter.go:21 +0x11b
  github.com/AccelByte/go-restful-plugins/v4/pkg/logger/log.AccessLog()
      /opt/go/pkg/mod/github.com/!accel!byte/go-restful-plugins/v4@v4.21.0/pkg/logger/log/accesslog.go:134 +0x744
  github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/filter.go:21 +0x11b
  accelbyte.net/justice-chat-service/pkg/server.New.Filter.func1()
      /opt/go/pkg/mod/github.com/!accel!byte/go-restful-plugins/v4@v4.21.0/pkg/jaeger/jaeger.go:44 +0x32b
  github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/filter.go:21 +0x11b
  accelbyte.net/justice-chat-service/pkg/server.New.FilterWithOption.initFilter.func12()
      /opt/go/pkg/mod/github.com/!accel!byte/go-restful-plugins/v4@v4.21.0/pkg/trace/trace.go:64 +0x2c4
  github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/filter.go:21 +0x11b
  github.com/emicklei/go-restful/v3.(*Container).OPTIONSFilter()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/options_filter.go:15 +0x32f
  github.com/emicklei/go-restful/v3.(*Container).OPTIONSFilter-fm()
      <autogenerated>:1 +0x51
  github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/filter.go:21 +0x11b
  github.com/AccelByte/go-restful-plugins/v4/pkg/cors.CrossOriginResourceSharing.Filter()
      /opt/go/pkg/mod/github.com/!accel!byte/go-restful-plugins/v4@v4.21.0/pkg/cors/cors_filter.go:52 +0x2cf
  github.com/AccelByte/go-restful-plugins/v4/pkg/cors.CrossOriginResourceSharing.Filter-fm()
      <autogenerated>:1 +0xdb
  github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/filter.go:21 +0x11b
  github.com/emicklei/go-restful/v3.(*Container).dispatch()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/container.go:296 +0x92f
  github.com/emicklei/go-restful/v3.(*Container).dispatch-fm()
      <autogenerated>:1 +0x51
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2136 +0x47
  net/http.(*ServeMux).ServeHTTP()
      /usr/local/go/src/net/http/server.go:2514 +0xbc
  github.com/emicklei/go-restful/v3.(*Container).ServeHTTP()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/container.go:316 +0x384
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2938 +0x2a1
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:2009 +0xc24
  net/http.(*Server).Serve.func3()
      /usr/local/go/src/net/http/server.go:3086 +0x4f

Goroutine 23769 (running) created at:
  github.com/AccelByte/eventstream-go-sdk/v3.(*KafkaClient).publishAndRetryFailure()
      /opt/go/pkg/mod/github.com/!accel!byte/eventstream-go-sdk/v3@v3.17.0/kafka.go:406 +0x3e7
  github.com/AccelByte/eventstream-go-sdk/v3.(*KafkaClient).PublishAuditLog()
      /opt/go/pkg/mod/github.com/!accel!byte/eventstream-go-sdk/v3@v3.17.0/kafka.go:394 +0x204
  accelbyte.net/justice-chat-service/pkg/auditlog.(*Publisher).PublishAuditLogWithOptions()
      /opt/go/src/accelbyte.net/justice-chat-service/pkg/auditlog/auditlog.go:246 +0xcf1
  accelbyte.net/justice-chat-service/pkg/filter/api.(*Handler).handleDelete()
      /opt/go/src/accelbyte.net/justice-chat-service/pkg/filter/api/handler.go:281 +0x385
  accelbyte.net/justice-chat-service/pkg/filter/api.(*Handler).handleDelete-fm()
      <autogenerated>:1 +0x47
  github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/filter.go:23 +0x141
  accelbyte.net/justice-chat-service/pkg/route-filters.WrapWithAuthFilter.(*Filter).Auth.func3()
      /opt/go/pkg/mod/github.com/!accel!byte/go-restful-plugins/v4@v4.21.0/pkg/auth/iam/iam.go:207 +0xb5d
  github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/filter.go:21 +0x11b
  accelbyte.net/justice-chat-service/pkg/filter/api.AddAdminProfanityV1Route.ValidatePathParams.func11()
      /opt/go/src/accelbyte.net/justice-chat-service/pkg/utils/restapi/validationfilter.go:54 +0x6b5
  github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/filter.go:21 +0x11b
  accelbyte.net/justice-chat-service/pkg/server.New.Log.func6()
      /opt/go/pkg/mod/github.com/!accel!byte/go-restful-plugins/v4@v4.21.0/pkg/logger/event/event.go:91 +0x209
  github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/filter.go:21 +0x11b
  github.com/AccelByte/go-restful-plugins/v4/pkg/logger/log.AccessLog()
      /opt/go/pkg/mod/github.com/!accel!byte/go-restful-plugins/v4@v4.21.0/pkg/logger/log/accesslog.go:134 +0x744
  github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/filter.go:21 +0x11b
  accelbyte.net/justice-chat-service/pkg/server.New.Filter.func1()
      /opt/go/pkg/mod/github.com/!accel!byte/go-restful-plugins/v4@v4.21.0/pkg/jaeger/jaeger.go:44 +0x32b
  github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/filter.go:21 +0x11b
  accelbyte.net/justice-chat-service/pkg/server.New.FilterWithOption.initFilter.func12()
      /opt/go/pkg/mod/github.com/!accel!byte/go-restful-plugins/v4@v4.21.0/pkg/trace/trace.go:64 +0x2c4
  github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/filter.go:21 +0x11b
  github.com/emicklei/go-restful/v3.(*Container).OPTIONSFilter()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/options_filter.go:15 +0x32f
  github.com/emicklei/go-restful/v3.(*Container).OPTIONSFilter-fm()
      <autogenerated>:1 +0x51
  github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/filter.go:21 +0x11b
  github.com/AccelByte/go-restful-plugins/v4/pkg/cors.CrossOriginResourceSharing.Filter()
      /opt/go/pkg/mod/github.com/!accel!byte/go-restful-plugins/v4@v4.21.0/pkg/cors/cors_filter.go:52 +0x2cf
  github.com/AccelByte/go-restful-plugins/v4/pkg/cors.CrossOriginResourceSharing.Filter-fm()
      <autogenerated>:1 +0xdb
  github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/filter.go:21 +0x11b
  github.com/emicklei/go-restful/v3.(*Container).dispatch()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/container.go:296 +0x92f
  github.com/emicklei/go-restful/v3.(*Container).dispatch-fm()
      <autogenerated>:1 +0x51
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2136 +0x47
  net/http.(*ServeMux).ServeHTTP()
      /usr/local/go/src/net/http/server.go:2514 +0xbc
  github.com/emicklei/go-restful/v3.(*Container).ServeHTTP()
      /opt/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.11.2/container.go:316 +0x384
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2938 +0x2a1
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:2009 +0xc24
  net/http.(*Server).Serve.func3()
      /usr/local/go/src/net/http/server.go:3086 +0x4f
==================```