### PR TITLE
[V4] Refactor to avoid spawning goroutine on every publish and fix gauge metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ clean:
 test:
 	docker-compose -f docker-compose-test.yml up -d -V
 	sleep 30
-	go test -v ./...
+	go test -race -v ./...
 	docker-compose -f docker-compose-test.yml down
 
 coverage:

--- a/README.md
+++ b/README.md
@@ -170,7 +170,6 @@ err := client.Publish(
 * Privacy : Privacy. Backward compatibility. (bool)
 * AdditionalFields : Additional fields. Backward compatibility. (map[string]interface{})
 * Payload : Additional attribute. (map[string]interface{})
-* ErrorCallback : Callback function when event failed to publish. (func(event *Event, err error){})
 
 ### Subscribe
 To subscribe an event from specific topic in stream, client should be register a callback function that executed once event received.

--- a/eventstream.go
+++ b/eventstream.go
@@ -145,7 +145,6 @@ type PublishBuilder struct {
 	additionalFields map[string]interface{}
 	key              string
 	payload          map[string]interface{}
-	errorCallback    func(_ *Event, err error)
 	ctx              context.Context
 	timeout          time.Duration
 }
@@ -153,9 +152,8 @@ type PublishBuilder struct {
 // NewPublish create new PublishBuilder instance
 func NewPublish() *PublishBuilder {
 	return &PublishBuilder{
-		version:       defaultVersion,
-		ctx:           context.Background(),
-		errorCallback: nil,
+		version: defaultVersion,
+		ctx:     context.Background(),
 	}
 }
 
@@ -288,18 +286,6 @@ func (p *PublishBuilder) Key(key string) *PublishBuilder {
 // Payload is a event payload that will be published
 func (p *PublishBuilder) Payload(payload map[string]interface{}) *PublishBuilder {
 	p.payload = payload
-	return p
-}
-
-// ErrorCallback function to handle the event when failed to publish.
-//
-// Deprecated: As the underlying client handles error asynchronously, it's not possible to pass the Event to the
-// error callback internally unless every Event is tracked inside the eventstream library (but it will introduce unnecessary
-// complexity).
-//
-// This ErrorCallback will still be triggered when delivery error occurred, but the Event will always be nil.
-func (p *PublishBuilder) ErrorCallback(errorCallback func(_ *Event, err error)) *PublishBuilder {
-	p.errorCallback = errorCallback
 	return p
 }
 

--- a/eventstream.go
+++ b/eventstream.go
@@ -145,7 +145,7 @@ type PublishBuilder struct {
 	additionalFields map[string]interface{}
 	key              string
 	payload          map[string]interface{}
-	errorCallback    func(event *Event, err error)
+	errorCallback    func(_ *Event, err error)
 	ctx              context.Context
 	timeout          time.Duration
 }
@@ -291,8 +291,14 @@ func (p *PublishBuilder) Payload(payload map[string]interface{}) *PublishBuilder
 	return p
 }
 
-// ErrorCallback function to handle the event when failed to publish
-func (p *PublishBuilder) ErrorCallback(errorCallback func(event *Event, err error)) *PublishBuilder {
+// ErrorCallback function to handle the event when failed to publish.
+//
+// Deprecated: As the underlying client handles error asynchronously, it's not possible to pass the Event to the
+// error callback internally unless every Event is tracked inside the eventstream library (but it will introduce unnecessary
+// complexity).
+//
+// This ErrorCallback will still be triggered when delivery error occurred, but the Event will always be nil.
+func (p *PublishBuilder) ErrorCallback(errorCallback func(_ *Event, err error)) *PublishBuilder {
 	p.errorCallback = errorCallback
 	return p
 }
@@ -360,7 +366,7 @@ func (s *SubscribeBuilder) GroupInstanceID(groupInstanceID string) *SubscribeBui
 	return s
 }
 
-// EventName set event name that will be subscribe
+// EventName set event name that will be subscribed
 func (s *SubscribeBuilder) EventName(eventName string) *SubscribeBuilder {
 	s.eventName = eventName
 	return s

--- a/kafka_integration_test.go
+++ b/kafka_integration_test.go
@@ -422,23 +422,8 @@ func TestKafkaPubFailed(t *testing.T) {
 
 	errorCallback := func(event *Event, err error) {
 		assert.NotNil(t, err, "error should not be nil")
-		assert.Equal(t, mockEvent.EventName, event.EventName, "event name should be equal")
-		assert.Equal(t, mockEvent.Namespace, event.Namespace, "namespace should be equal")
-		assert.Equal(t, mockEvent.ClientID, event.ClientID, "client ID should be equal")
-		assert.Equal(t, mockEvent.TraceID, event.TraceID, "trace ID should be equal")
-		assert.Equal(t, mockEvent.SpanContext, event.SpanContext, "span context should be equal")
-		assert.Equal(t, mockEvent.UserID, event.UserID, "user ID should be equal")
-		assert.Equal(t, mockEvent.SessionID, event.SessionID, "session ID should be equal")
-		assert.Equal(t, mockEvent.EventID, event.EventID, "EventID should be equal")
-		assert.Equal(t, mockEvent.EventType, event.EventType, "EventType should be equal")
-		assert.Equal(t, mockEvent.EventLevel, event.EventLevel, "EventLevel should be equal")
-		assert.Equal(t, mockEvent.ServiceName, event.ServiceName, "ServiceName should be equal")
-		assert.Equal(t, mockEvent.ClientIDs, event.ClientIDs, "ClientIDs should be equal")
-		assert.Equal(t, mockEvent.TargetUserIDs, event.TargetUserIDs, "TargetUserIDs should be equal")
-		assert.Equal(t, mockEvent.TargetNamespace, event.TargetNamespace, "TargetNamespace should be equal")
-		assert.Equal(t, mockEvent.Privacy, event.Privacy, "Privacy should be equal")
-		assert.Equal(t, mockEvent.AdditionalFields, event.AdditionalFields, "AdditionalFields should be equal")
-		assert.Equal(t, mockEvent.Version, event.Version, "version should be equal")
+		assert.Nil(t, event)
+
 		doneChan <- true
 	}
 

--- a/kafka_test.go
+++ b/kafka_test.go
@@ -355,7 +355,6 @@ func makePayload(keyLength, messageLength int) map[string]interface{} {
 }
 
 func TestKafkaMaxMessageSize(t *testing.T) {
-	t.Parallel()
 	client := createKafkaClient(t)
 	topicName := constructTopicTest()
 
@@ -422,8 +421,6 @@ func TestKafkaMaxMessageSize(t *testing.T) {
 }
 
 func TestKafkaMaxMessageSizeModified(t *testing.T) {
-	t.Parallel()
-
 	config := &BrokerConfig{
 		CACertFile:       "",
 		StrictValidation: true,

--- a/kafkaprometheus/collectors.go
+++ b/kafkaprometheus/collectors.go
@@ -97,9 +97,7 @@ func counter(counter *prometheus.CounterVec, value int64, labels ...string) prom
 
 func gauge(gauge *prometheus.GaugeVec, value float64, labels ...string) prometheus.Metric {
 	m := gauge.WithLabelValues(labels...)
-	if value != 0 {
-		m.Set(value)
-	}
+	m.Set(value)
 	return m
 }
 

--- a/v3/pkg/kafkaprometheus/collectors.go
+++ b/v3/pkg/kafkaprometheus/collectors.go
@@ -79,9 +79,7 @@ func counter(counter *prometheus.CounterVec, value int64, labels ...string) prom
 
 func gauge(gauge *prometheus.GaugeVec, value float64, labels ...string) prometheus.Metric {
 	m := gauge.WithLabelValues(labels...)
-	if value != 0 {
-		m.Set(value)
-	}
+	m.Set(value)
 	return m
 }
 


### PR DESCRIPTION
- Refactor to avoid spawning goroutine on every publish since the underlying client behavior is async already. I did a test to produce 1 million messages in a loop, and it is proven that this change could significantly reduce memory usage compared to the previous version. The duration needed to call produce 1 million messages are still similar: 10.706964576 seconds (after) vs 10.617837814 seconds (before).  Here is the alloc memory comparison between before vs after the change: 
![image](https://github.com/AccelByte/eventstream-go-sdk/assets/31310263/dc5651b3-cfc6-4721-883f-21fd6aa25feb)
- Changed the gauge metric to allow setting zero value. It's important because the consumer lag metric was never set back to zero before
- Remove `PublishBuilder.ErrorCallback`, as the underlying client handles error asynchronously, there is no easy way to link each Event with the library's delivery error.

