### PR TITLE
feat(v4): expose Kafka headers

### DIFF
--- a/eventstream.go
+++ b/eventstream.go
@@ -54,6 +54,13 @@ const (
 	ErrorLevel = "error"
 )
 
+// EventMetadata defines the structure of event metadata
+type EventMetadata struct {
+	Partition int    `json:",omitempty"`
+	Offset    int64  `json:",omitempty"`
+	Key       string `json:",omitempty"`
+}
+
 // Event defines the structure of event
 type Event struct {
 	ID               string                 `json:"id,omitempty"`
@@ -356,7 +363,7 @@ type SubscribeBuilder struct {
 	eventName           string
 	ctx                 context.Context
 	callbackRaw         func(ctx context.Context, msgValue []byte, err error) error
-	callbackWithHeaders func(ctx context.Context, msgValue []byte, headers []Header, err error) error
+	callbackWithHeaders func(ctx context.Context, msgValue []byte, headers []Header, metadata *EventMetadata, err error) error
 	// flag to send error message to DLQ
 	sendErrorDLQ bool
 	// flag to use async commit consumer
@@ -419,7 +426,7 @@ func (s *SubscribeBuilder) CallbackRaw(
 
 // CallbackWithHeaders callback that receives the undecoded payload and headers
 func (s *SubscribeBuilder) CallbackWithHeaders(
-	f func(ctx context.Context, msgValue []byte, headers []Header, err error) error,
+	f func(ctx context.Context, msgValue []byte, headers []Header, metadata *EventMetadata, err error) error,
 ) *SubscribeBuilder {
 	s.callbackWithHeaders = f
 	return s

--- a/kafka_integration_test.go
+++ b/kafka_integration_test.go
@@ -1116,7 +1116,7 @@ func TestKafkaPubSubWithHeaders(t *testing.T) {
 			GroupID(groupID).
 			Offset(0).
 			Context(ctx).
-			CallbackWithHeaders(func(ctx context.Context, _ []byte, headers []Header, err error) error {
+			CallbackWithHeaders(func(ctx context.Context, _ []byte, headers []Header, metadata *EventMetadata, err error) error {
 				if ctx.Err() != nil {
 					return ctx.Err()
 				}
@@ -1127,6 +1127,8 @@ func TestKafkaPubSubWithHeaders(t *testing.T) {
 
 				require.NotEmpty(t, headers)
 				require.Equal(t, expectedHeaders, headers)
+				require.NotNil(t, metadata)
+				require.Equal(t, "somekey", metadata.Key)
 
 				doneChan <- true
 
@@ -1156,7 +1158,8 @@ func TestKafkaPubSubWithHeaders(t *testing.T) {
 			Context(context.Background()).
 			Timeout(10 * time.Second).
 			Payload(mockPayload).
-			Headers(expectedHeaders))
+			Headers(expectedHeaders).
+			Key("somekey"))
 	require.NoError(t, err)
 
 	for {

--- a/validation.go
+++ b/validation.go
@@ -147,7 +147,7 @@ func validateSubscribeEvent(subscribeBuilder *SubscribeBuilder) error {
 		GroupID             string
 		Callback            func(ctx context.Context, event *Event, err error) error
 		CallbackRaw         func(ctx context.Context, msg []byte, err error) error
-		CallbackWithHeaders func(ctx context.Context, msg []byte, headers []Header, err error) error
+		CallbackWithHeaders func(ctx context.Context, msg []byte, headers []Header, metadata *EventMetadata, err error) error
 	}{
 		Topic:               subscribeBuilder.topic,
 		EventName:           subscribeBuilder.eventName,


### PR DESCRIPTION
The lobby service needs to retrieve the user's sequence ID before processing the message. Attaching the sequence ID to the event payload requires decoding the payload first, which currently happens on the worker. Moving this step outside the worker would slow down the Kafka message consumption rate. 
By using headers, the lobby service can retrieve the user's sequence ID from the Kafka message without needing to decode the payload before sending it to the workers.