### PR TITLE
fix: support source namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ err := client.Publish(
 * ClientIDs : List of client IDs. Backward compatibility. ([]string - UUID v4 without Hyphens)
 * TargetUserIDs : List of target client IDs. Backward compatibility. ([]string - UUID v4 without Hyphens)
 * TargetNamespace : Target Namespace. Backward compatibility. (string)
+* SourceNamespace : Source Namespace. Backward compatibility. SourceNamespace tracks the trigger namespace, distinct from the event's occurrence namespace. (string  - optional)
 * Privacy : Privacy. Backward compatibility. (bool)
 * AdditionalFields : Additional fields. Backward compatibility. (map[string]interface{})
 * Payload : Additional attribute. (map[string]interface{})

--- a/v3/eventstream.go
+++ b/v3/eventstream.go
@@ -77,6 +77,7 @@ type Event struct {
 	TargetNamespace   string                 `json:"target_namespace,omitempty"`
 	Privacy           bool                   `json:"privacy,omitempty"`
 	Topic             string                 `json:"topic,omitempty"`
+	SourceNamespace  string                  `json:"sourceNamespace,omitempty"`
 	AdditionalFields  map[string]interface{} `json:"additional_fields,omitempty"`
 	Payload           map[string]interface{} `json:"payload,omitempty"`
 
@@ -141,6 +142,7 @@ type PublishBuilder struct {
 	errorCallback    func(event *Event, err error)
 	ctx              context.Context
 	timeout          time.Duration
+	sourceNamespace  string
 }
 
 // NewPublish create new PublishBuilder instance
@@ -256,6 +258,12 @@ func (p *PublishBuilder) TargetUserIDs(targetUserIDs []string) *PublishBuilder {
 // TargetNamespace set targetNamespace of publisher event
 func (p *PublishBuilder) TargetNamespace(targetNamespace string) *PublishBuilder {
 	p.targetNamespace = targetNamespace
+	return p
+}
+
+// SourceNamespace set sourceNamespace of publisher event
+func (p *PublishBuilder) SourceNamespace(sourceNamespace string) *PublishBuilder {
+	p.sourceNamespace = sourceNamespace
 	return p
 }
 

--- a/v3/kafka.go
+++ b/v3/kafka.go
@@ -538,6 +538,7 @@ func ConstructEvent(publishBuilder *PublishBuilder) (kafka.Message, *Event, erro
 		Privacy:           publishBuilder.privacy,
 		AdditionalFields:  publishBuilder.additionalFields,
 		Payload:           publishBuilder.payload,
+		SourceNamespace:   publishBuilder.sourceNamespace,
 	}
 
 	eventBytes, err := marshal(event)

--- a/v3/stdout.go
+++ b/v3/stdout.go
@@ -71,6 +71,7 @@ func (client *StdoutClient) Publish(publishBuilder *PublishBuilder) error {
 		AdditionalFields:  publishBuilder.additionalFields,
 		Version:           publishBuilder.version,
 		Payload:           publishBuilder.payload,
+		SourceNamespace:   publishBuilder.sourceNamespace,
 	}
 
 	eventByte, err := marshal(event)


### PR DESCRIPTION
context: IAM has some event related to login, the root path namespace is always publisher namespace, if login with game namespace, we need add this source namespace. So other team, like AIS can know the correct behavior.
@wardab0104 @marselab @angelo-chan 